### PR TITLE
Add a build-ready source zip to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,14 @@ jobs:
       run: corepack yarn install --immutable
 
     - name: Build
-      run: corepack yarn build
+      run: corepack yarn run build
 
     - name: web-ext lint
       run: corepack yarn exec web-ext lint --pretty --output=json
 
-    - run: npx changelogithub@13.16.0 --assets 'dist/*.xpi'
+    - name: Create a source zip
+      run: corepack yarn run archive
+
+    - run: npx changelogithub@13.16.0 --assets 'dist/*.xpi' --assets 'dist/*.zip'
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,13 @@
 # This Makefile is here so that `make build` is a bit shorter than
 # `corepack enable && yarn install && yarn build`
 
-.PHONY: all archive build check clean deepclean devenv dist doc fmt fix js start test web-ext xpi
+.PHONY: all build check clean deepclean devenv dist doc fmt fix js start test web-ext xpi
 
 GIT=git
 YARN=corepack yarn
 CP=cp
 
-all: test xpi doc archive
-
-archive: build/
-	$(GIT) archive --output="build/src-$$($(GIT) describe --always --long --tags).zip" HEAD
+all: test xpi
 
 build: xpi
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "sdk": "yarn dlx @yarnpkg/sdks",
+    "archive": "NAME=$(basename dist/*.xpi .xpi)-src && git archive --output=dist/${NAME}.zip --prefix=${NAME}/ext/ --add-file=dist/ext/manifest.json --prefix=${NAME}/ HEAD",
     "barrelsby": "node --experimental-strip-types tools/barrelsby.ts",
     "check": "run check-type && biome check --error-on-warnings",
     "fix": "biome check --write",


### PR DESCRIPTION
I've noticed that we could produce a source zip file that can reproduce the XPI binary. Let's release it along with the XPI file.